### PR TITLE
improve suffixes + fix .rc compilation with MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,9 @@ set(ZLIB_SRCS
     uncompr.c
     zutil.c)
 
-set_source_files_properties(win32/zlib1.rc PROPERTIES
-    COMPILE_FLAGS $<$<STREQUAL:${CMAKE_RC_OUTPUT_EXTENSION},.obj>:-DGCC_WINDRES>)
+if(MINGW)
+    set_source_files_properties(win32/zlib1.rc PROPERTIES COMPILE_FLAGS "-DGCC_WINDRES")
+endif()
 
 # Add a suffix before the extension to avoid conflicting static
 # lib and shared implib name (typically with MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,9 +79,8 @@ set(ZLIB_SRCS
     uncompr.c
     zutil.c)
 
-if(MINGW)
-    set_source_files_properties(win32/zlib1.rc PROPERTIES COMPILE_FLAGS "-DGCC_WINDRES")
-endif(MINGW)
+set_source_files_properties(win32/zlib1.rc PROPERTIES
+    COMPILE_FLAGS $<$<BOOL:${MINGW}>:-DGCC_WINDRES>)
 
 # Add a suffix before the extension to avoid conflicting static
 # lib and shared implib name (typically with MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,10 +82,13 @@ set(ZLIB_SRCS
 set_source_files_properties(win32/zlib1.rc PROPERTIES
     COMPILE_FLAGS $<$<STREQUAL:${CMAKE_RC_OUTPUT_EXTENSION},.obj>:-DGCC_WINDRES>)
 
-if(WIN32)
-    set (zlib_static_suffix "s")
-    set (zlib_debug_suffix "d")
-endif(WIN32)
+# Add a suffix before the extension to avoid conflicting static
+# lib and shared implib name (typically with MSVC)
+if(WIN32 AND
+   NOT ZLIB_STATIC_LIB_SUFFIX AND
+   CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX)
+    set(ZLIB_STATIC_LIB_SUFFIX "s")
+endif()
 
 if(ZLIB_BUILD_SHARED)
     add_library(zlib SHARED
@@ -113,8 +116,7 @@ if(ZLIB_BUILD_SHARED)
     set_target_properties(zlib PROPERTIES
         DEFINE_SYMBOL ZLIB_DLL
         SOVERSION 1
-        PROPERTIES OUTPUT_NAME z
-        PROPERTIES OUTPUT_NAME_DEBUG z${zlib_debug_suffix}
+        OUTPUT_NAME z
         $<$<BOOL:NOT:$CYGWIN}>:VERSION ${zlib_VERSION}>)
     if(UNIX AND NOT APPLE AND NOT(CMAKE_SYSTEM_NAME STREQUAL AIX))
         # On unix-like platforms the library is almost always called libz
@@ -139,8 +141,8 @@ if(ZLIB_BUILD_STATIC)
         PUBLIC
             $<$<BOOL:${HAVE_OFF64_T}>:_LARGEFILE64_SOURCE=1>)
     set_target_properties(zlibstatic PROPERTIES
-        PROPERTIES OUTPUT_NAME z${zlib_static_suffix}
-        PROPERTIES OUTPUT_NAME_DEBUG z${zlib_static_suffix}${zlib_debug_suffix})
+        OUTPUT_NAME z
+        SUFFIX "${ZLIB_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}")
 endif(ZLIB_BUILD_STATIC)
 
 if(ZLIB_INSTALL_LIBRARIES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ set(ZLIB_SRCS
 
 if(MINGW)
     set_source_files_properties(win32/zlib1.rc PROPERTIES COMPILE_FLAGS "-DGCC_WINDRES")
-endif()
+endif(MINGW)
 
 # Add a suffix before the extension to avoid conflicting static
 # lib and shared implib name (typically with MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,10 @@ if(ZLIB_BUILD_SHARED)
         SOVERSION 1
         OUTPUT_NAME z
         $<$<BOOL:NOT:$CYGWIN}>:VERSION ${zlib_VERSION}>)
+    if(WIN32)
+        set_target_properties(zlib PROPERTIES
+            SUFFIX "${zlib_VERSION_MAJOR}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    endif(WIN32)
     if(UNIX AND NOT APPLE AND NOT(CMAKE_SYSTEM_NAME STREQUAL AIX))
         # On unix-like platforms the library is almost always called libz
         set_target_properties(zlib PROPERTIES
@@ -155,7 +159,6 @@ if(ZLIB_INSTALL_LIBRARIES)
         if(ZLIB_INSTALL_COMPAT_DLL)
             install(FILES  $<TARGET_FILE:zlib>
                 COMPONENT Runtime
-                RENAME zlib1.dll
                 DESTINATION "${CMAKE_INSTALL_BINDIR}")
         endif(ZLIB_INSTALL_COMPAT_DLL)
 


### PR DESCRIPTION
- Honor CMake's `CMAKE_DEBUG_POSTFIX` when forming
  output filenames. Can be customized freely.

- detect when static lib and implib would clash (= MSVC) and apply
  a default "s" suffix to the static lib in that case.

- allow to override the static lib suffix via `ZLIB_STATIC_LIB_SUFFIX`.
  This also overrides the "s" above.

- `-DGCC_WINDRES` is required for `windres`. Make sure to pass it
  when detected. (FWIW this PP macro/logic seems unnecessary/obsolete,
  but that's not a CMake issue.)

- build `zlib1.dll` right away on Windows.
  Instead of renaming to that on install.
  Derive `1` from the zlib version.
